### PR TITLE
Close encrypted file filestream

### DIFF
--- a/EPPlus/Utils/CompundDocument/CompoundDocumentFile.cs
+++ b/EPPlus/Utils/CompundDocument/CompoundDocumentFile.cs
@@ -114,10 +114,12 @@ namespace OfficeOpenXml.Utils.CompundDocument
         {
             try
             {
-                var fs = fi.OpenRead();
-                var b = new byte[8];
-                fs.Read(b, 0, 8);
-                return IsCompoundDocument(b);
+                using (var fs = fi.OpenRead())
+                {
+                    var b = new byte[8];
+                    fs.Read(b, 0, 8);
+                    return IsCompoundDocument(b);
+                }
             }
             catch
             {


### PR DESCRIPTION
An error "Error saving file {file path}" occurred when saving an encrypted file.

```
using (ExcelPackage pck = new ExcelPackage(new FileInfo("path/to/encrypted/file.xlsx"), true, "password"))            
 {
    // Excel operation processing

    pck.Save(); // Error saving file path/to/encrypted/file.xlsx
 }
```
The process was locked because there was a file stream that was not closed.
The error disappeared when I corrected it.

You can test with "EPPlusTest.Encrypt.ReadWriteEncrypt()".

I am glad if you merge because it is necessary for business.

Created by ZakkyR