### PR TITLE
Bug resovled: Supporting Font Charset attribute

### DIFF
--- a/EPPlus/EPPlus.MultiTarget.csproj
+++ b/EPPlus/EPPlus.MultiTarget.csproj
@@ -2,9 +2,9 @@
 
   <PropertyGroup>
     <TargetFrameworks>netcoreapp2.1;netstandard2.0;net35;net40</TargetFrameworks>
-    <AssemblyVersion>4.5.3.2</AssemblyVersion>
-    <FileVersion>4.5.3.2</FileVersion>
-    <Version>4.5.3.2</Version>
+    <AssemblyVersion>4.5.3.4</AssemblyVersion>
+    <FileVersion>4.5.3.4</FileVersion>
+    <Version>4.5.3.4</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageLicenseUrl>https://licenses.nuget.org/LGPL-3.0-or-later</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/JanKallman/EPPlus</PackageProjectUrl>
@@ -17,7 +17,7 @@
     <RepositoryUrl></RepositoryUrl>
     <PackageTags>Excel ooxml</PackageTags>
     <Copyright>Jan Källman 2018</Copyright>
-    <PackageReleaseNotes>EPPlus 4.5.3.2
+    <PackageReleaseNotes>EPPlus 4.5.3.4
 
 New features in version 4.5:
 * .NET Core support

--- a/EPPlus/ExcelWorkbook.cs
+++ b/EPPlus/ExcelWorkbook.cs
@@ -308,7 +308,7 @@ namespace OfficeOpenXml
 		#region Workbook Properties
 		decimal _standardFontWidth = decimal.MinValue;
         string _fontID = "";
-        internal FormulaParser FormulaParser
+        public FormulaParser FormulaParser
         {
             get
             {

--- a/EPPlus/Style/ExcelFont.cs
+++ b/EPPlus/Style/ExcelFont.cs
@@ -90,6 +90,20 @@ namespace OfficeOpenXml.Style
             }
         }
         /// <summary>
+        /// Font charset
+        /// </summary>
+        public int Charset
+        {
+            get
+            {
+                return _styles.Fonts[Index].Charset;
+            }
+            set
+            {
+                _ChangedEvent(this, new StyleChangeEventArgs(eStyleClass.Font, eStyleProperty.Charset, value, _positionID, _address));
+            }
+        }
+        /// <summary>
         /// Cell color
         /// </summary>
         public ExcelColor Color
@@ -222,13 +236,14 @@ namespace OfficeOpenXml.Style
             Bold = Font.Bold;
             UnderLine = Font.Underline;
             Italic = Font.Italic;
+            Charset = Font.GdiCharSet;
         }
 
         internal override string Id
         {
             get 
             {
-                return Name + Size.ToString() + Family.ToString() + Scheme.ToString() + Bold.ToString()[0] + Italic.ToString()[0] + Strike.ToString()[0] + UnderLine.ToString()[0] + VerticalAlign;
+                return Name + Size.ToString() + Family.ToString() + Charset.ToString() + Scheme.ToString() + Bold.ToString()[0] + Italic.ToString()[0] + Strike.ToString()[0] + UnderLine.ToString()[0] + VerticalAlign;
             }
         }
     }

--- a/EPPlus/Style/StyleChangeEventArgs.cs
+++ b/EPPlus/Style/StyleChangeEventArgs.cs
@@ -91,7 +91,8 @@ namespace OfficeOpenXml.Style
         GradientRight,
         XfId,
         Indent,
-        QuotePrefix
+        QuotePrefix,
+        Charset
     }
     internal class StyleChangeEventArgs : EventArgs
     {

--- a/EPPlus/Style/XmlAccess/ExcelFontXml.cs
+++ b/EPPlus/Style/XmlAccess/ExcelFontXml.cs
@@ -48,6 +48,7 @@ namespace OfficeOpenXml.Style.XmlAccess
             _name = "";
             _size = 0;
             _family = int.MinValue;
+            _charset = int.MinValue;
             _scheme = "";
             _color = _color = new ExcelColorXml(NameSpaceManager);
             _bold = false;
@@ -62,6 +63,7 @@ namespace OfficeOpenXml.Style.XmlAccess
             _name = GetXmlNodeString(namePath);
             _size = (float)GetXmlNodeDecimal(sizePath);
             _family = GetXmlNodeIntNull(familyPath)??int.MinValue;
+            _charset = GetXmlNodeIntNull(charsetPath)??int.MinValue;
             _scheme = GetXmlNodeString(schemePath);
             _color = new ExcelColorXml(nsm, topNode.SelectSingleNode(_colorPath, nsm));
             _bold = GetBoolValue(topNode, boldPath);
@@ -140,6 +142,22 @@ namespace OfficeOpenXml.Style.XmlAccess
             set
             {
                 _family=value;
+            }
+        }
+        const string charsetPath = "d:charset/@val";
+        int _charset;
+        /// <summary>
+        /// Font Charset
+        /// </summary>
+        public int Charset
+        {
+            get
+            {
+                return (_charset == int.MinValue ? 1 : _charset); //  DEFAULT Charset
+            }
+            set
+            {
+                _charset = value;
             }
         }
         ExcelColorXml _color = null;
@@ -278,6 +296,7 @@ namespace OfficeOpenXml.Style.XmlAccess
             Bold = Font.Bold;
             UnderLine=Font.Underline;
             Italic=Font.Italic;
+            Charset = Font.GdiCharSet; // default is 1
         }
         public static float GetFontHeight(string name, float size)
         {
@@ -332,6 +351,7 @@ namespace OfficeOpenXml.Style.XmlAccess
             newFont.Name = _name;
             newFont.Size = _size;
             newFont.Family = _family;
+            newFont.Charset = _charset;
             newFont.Scheme = _scheme;
             newFont.Bold = _bold;
             newFont.Italic = _italic;
@@ -372,6 +392,7 @@ namespace OfficeOpenXml.Style.XmlAccess
             }
             if(!string.IsNullOrEmpty(_name)) SetXmlNodeString(namePath, _name);
             if(_family>int.MinValue) SetXmlNodeString(familyPath, _family.ToString());
+            if(_charset>int.MinValue) SetXmlNodeString(charsetPath, _charset.ToString());
             if (_scheme != "") SetXmlNodeString(schemePath, _scheme.ToString());
 
             return TopNode;

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# EPPlus
+# EPPlus With Font Charset Support
 Create advanced Excel spreadsheets using .NET, without the need of interop.
 
 EPPlus is a .NET library that reads and writes Excel files using the Office Open XML format (xlsx). 

--- a/SampleApp.Core/Sample17.cs
+++ b/SampleApp.Core/Sample17.cs
@@ -1,0 +1,127 @@
+﻿/*******************************************************************************
+ * You may amend and distribute as you like, but don't remove this header!
+ * 
+ * All rights reserved.
+ * 
+ * EPPlus is an Open Source project provided under the 
+ * GNU General Public License (GPL) as published by the 
+ * Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ * 
+ * EPPlus provides server-side generation of Excel 2007 spreadsheets.
+ * See https://github.com/JanKallman/EPPlus for details.
+ *
+ * 
+ * The GNU General Public License can be viewed at http://www.opensource.org/licenses/gpl-license.php
+ * If you unfamiliar with this license or have questions about it, here is an http://www.gnu.org/licenses/gpl-faq.html
+ * 
+ * The code for this project may be used and redistributed by any means PROVIDING it is 
+ * not sold for profit without the author's written consent, and providing that this notice 
+ * and the author's name and all copyright notices remain intact.
+ * 
+ * All code and executables are provided "as is" with no warranty either express or implied. 
+ * The author accepts no liability for any damage or loss of business that this product may cause.
+ *
+ *
+ * Code change notes:
+ * 
+ * Author							Change						Date
+ *******************************************************************************
+ * Jan Källman		Added		10-SEP-2009
+ *******************************************************************************/
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Diagnostics;
+using OfficeOpenXml;
+using System.IO;
+using System.Data.SqlClient;
+using OfficeOpenXml.Drawing;
+using OfficeOpenXml.Drawing.Chart;
+using OfficeOpenXml.Style;
+using System.Drawing;
+using OfficeOpenXml.FormulaParsing.Excel.Functions;
+using OfficeOpenXml.FormulaParsing.ExpressionGraph;
+using OfficeOpenXml.FormulaParsing;
+using System.Linq;
+
+namespace EPPlusSamples
+{
+    class EvaluateFunction : ExcelFunction
+    {
+        public override CompileResult Execute(IEnumerable<FunctionArgument> arguments, ParsingContext context)
+        {
+            ValidateArguments(arguments, 1);
+            var args = arguments.ToArray();
+            // renderer.customFunctionEvaluated = true;
+
+           double? hasDefaultVal = null;
+            if (args.Length > 1 && args[1].Value is double)
+            {
+                hasDefaultVal = (double)args[1].Value;
+            }
+            return new CompileResult(args[0].Value.ToString(), DataType.String);
+        }
+    }
+    class Sample17
+    {
+        /// <summary>
+        /// This sample creates a new workbook from a template file containing a chart and populates it with Exchangrates from 
+        /// the Adventureworks database and set the three series on the chart.
+        /// </summary>
+        /// <param name="connectionString">Connectionstring to the Adventureworks db</param>
+        /// <param name="template">the template</param>
+        /// <param name="outputdir">output dir</param>
+        /// <returns></returns>
+        public static string RunSample17(FileInfo template)
+        {
+            using (var stream = File.Open(template.FullName, FileMode.Open))
+            using (ExcelPackage p = new ExcelPackage(stream))
+            {
+                p.Workbook.FormulaParserManager.AddOrReplaceFunction("e", new EvaluateFunction());
+                //Set up the headers
+                ExcelWorksheet ws = p.Workbook.Worksheets[0];
+                for (int i=1; i<= ws.Dimension.Rows; i++)
+                {
+                    for (int j=1; j<=ws.Dimension.Columns; j++)
+                    {
+                        var cell = ws.Cells[i, j];
+                        if (cell.Merge)
+                            continue;
+                        var val = ws.Cells[i, j].Value;
+                        var formual = ws.Cells[i, j].Formula;
+                        if (!string.IsNullOrEmpty(formual))
+                        {
+                            var result = p.Workbook.FormulaParserManager.Parse(formual);
+                            var val2 = ws.Calculate(formual);
+                            ws.Cells[i, j].Formula = string.Empty;
+                            ws.Cells[i, j].Value = val2;
+                            Console.WriteLine($"{i},{j}: {val} and f={formual} and eval={val2}");
+                        }
+                    }
+                }
+                p.Workbook.Worksheets[0].Select();
+                
+                foreach (var a in ws.MergedCells)
+                {
+                    var cell = ws.Cells[a];
+                    var formual = cell.Formula;
+                    if (!string.IsNullOrEmpty(formual))
+                    {
+                        var tokens = p.Workbook.FormulaParser.Lexer.Tokenize(formual);
+                            //var result = p.Workbook.FormulaParserManager.Parse();
+                        var val2 = ws.Calculate(formual);
+                        cell.Formula = string.Empty;
+                        cell.Value = val2;
+                        Console.WriteLine($"{cell.Value} and f={formual} and eval={val2}");
+                    }
+                }
+                Byte[] bin = p.GetAsByteArray();
+
+                FileInfo file = Utils.GetFileInfo("sample17.xlsx");
+                File.WriteAllBytes(file.FullName, bin);
+                return file.FullName;
+            }
+        }
+    }
+}

--- a/SampleApp.Core/Sample_Main.cs
+++ b/SampleApp.Core/Sample_Main.cs
@@ -38,10 +38,21 @@ namespace EPPlusSamples
 {
 	class Sample_Main
 	{
+        static void Test()
+        {
+            Console.WriteLine("Running sample 4");
+            var sample17Path = Sample17.RunSample17(new FileInfo(@"C:\Users\mohammad\Desktop\DailyReportTemplate-v2.xlsx"));      //Template path from /bin/debug or /bin/release
+            Console.WriteLine("Sample 17 created: {0}", sample17Path);
+            Console.WriteLine();
+        }
 		static void Main(string[] args)
 		{
+            
 			try
 			{
+                Utils.OutputDir = new DirectoryInfo($"{AppDomain.CurrentDomain.BaseDirectory}SampleApp");
+                Test();
+                return;
                 //Sample 3, 4 and 12 uses the Adventureworks database. Enter the connectionstring to the Adventureworks database(2016 CTP3) into the variable below...
                 //Leave this blank if you don't have access to the Adventureworks database 
                 string connectionStr = "";      //for example "Integrated Security=SSPI;Persist Security Info=False;Initial Catalog=AdventureWorks2016CTP3;Data Source=MySqlServer"
@@ -177,7 +188,7 @@ namespace EPPlusSamples
 			}
             var prevColor = Console.ForegroundColor;
             Console.ForegroundColor = ConsoleColor.Green;
-            Console.WriteLine($"Genereted sample workbooks can be found in {Utils.OutputDir.FullName}");
+            Console.WriteLine($"Genereted sample workbooks can be found in {Utils.OutputDir?.FullName}");
             Console.ForegroundColor = prevColor;
 
             Console.WriteLine();


### PR DESCRIPTION
I have added Font Charset Property to the Font Style.
This Property is important for Non Default character sets.
The bug is shown when someone opens an excel file with the Font, the font does not appear to be applied.
Sample error: https://stackoverflow.com/questions/40032251/epplus-font-family-not-affected/40170340
Font class: https://docs.microsoft.com/en-us/dotnet/api/documentformat.openxml.wordprocessing.font?view=openxml-2.8.1

Created by mzatkhahi