### PR TITLE
Fix bug in Series

### DIFF
--- a/EPPlus/Drawing/Chart/ExcelScatterChart.cs
+++ b/EPPlus/Drawing/Chart/ExcelScatterChart.cs
@@ -135,7 +135,7 @@ namespace OfficeOpenXml.Drawing.Chart
             {
                 if (ScatterStyle==eScatterStyle.LineMarker)
                 {
-                    if (((ExcelScatterChartSerie)Series[0]).Marker == eMarkerStyle.None)
+                    if (Series.Count > 0 && ((ExcelScatterChartSerie)Series[0]).Marker == eMarkerStyle.None)
                     {
                         return eChartType.XYScatterLinesNoMarkers;
                     }
@@ -153,7 +153,7 @@ namespace OfficeOpenXml.Drawing.Chart
                 }
                 else if (ScatterStyle == eScatterStyle.SmoothMarker)
                 {
-                    if (((ExcelScatterChartSerie)Series[0]).Marker == eMarkerStyle.None)
+                    if (Series.Count > 0 && ((ExcelScatterChartSerie)Series[0]).Marker == eMarkerStyle.None)
                     {
                         return eChartType.XYScatterSmoothNoMarkers;
                     }


### PR DESCRIPTION
It is possible that Series has no elements. That means that Series[0] cannot be accessed. It was the case in my Excel file that I was working on.

I only have ScatterCharts in my Excel file, thus, if the other charts also assume that Series always has elements, this will fail in those cases.

Created by gxbag