### PR TITLE
Formula setting bug fix

### DIFF
--- a/EPPlus/ExcelRangeBase.cs
+++ b/EPPlus/ExcelRangeBase.cs
@@ -1540,13 +1540,23 @@ namespace OfficeOpenXml
             // if (value is string) _worksheet._types.SetValue(row, col, "S"); else _worksheet._types.SetValue(row, col, "");
             _worksheet._formulas.SetValue(row, col, "");
         }
-        internal void SetSharedFormulaID(int id)
+        internal void SetSharedFormulaID(int id, int? idOriginal = null)
         {
             for (int col = _fromCol; col <= _toCol; col++)
             {
                 for (int row = _fromRow; row <= _toRow; row++)
                 {
-                    _worksheet._formulas.SetValue(row, col, id);
+                    var f = _worksheet._formulas.GetValue(row, col);
+
+                    if (f is int)
+                    {
+                        int cellId = (int)f;
+
+                        if (cellId == id || (idOriginal.HasValue && cellId == idOriginal))
+                        {
+                            _worksheet._formulas.SetValue(row, col, id);
+                        }
+                    }
                 }
             }
         }
@@ -1618,6 +1628,7 @@ namespace OfficeOpenXml
                 //The formula partly collides with the current range
                 bool fIsSet = false;
                 string formulaR1C1 = fRange.FormulaR1C1;
+                int fIndexOriginal = f.Index;
                 //Top Range
                 if (fRange._fromRow < _fromRow)
                 {
@@ -1656,7 +1667,7 @@ namespace OfficeOpenXml
                              address._toRow, address._fromCol - 1);
                     }
                     f.Formula = TranslateFromR1C1(formulaR1C1, f.StartRow, f.StartCol);
-                    _worksheet.Cells[f.Address].SetSharedFormulaID(f.Index);
+                    _worksheet.Cells[f.Address].SetSharedFormulaID(f.Index, fIndexOriginal);
                 }
                 //Right Range
                 if (fRange._toCol > address._toCol)
@@ -1691,7 +1702,7 @@ namespace OfficeOpenXml
                                 address._toRow, fRange._toCol);
                     }
                     f.Formula = TranslateFromR1C1(formulaR1C1, f.StartRow, f.StartCol);
-                    _worksheet.Cells[f.Address].SetSharedFormulaID(f.Index);
+                    _worksheet.Cells[f.Address].SetSharedFormulaID(f.Index, fIndexOriginal);
                 }
                 //Bottom Range
                 if (fRange._toRow > address._toRow)
@@ -1711,7 +1722,7 @@ namespace OfficeOpenXml
 
                     f.Address = ExcelCellBase.GetAddress(f.StartRow, f.StartCol,
                             fRange._toRow, fRange._toCol);
-                    _worksheet.Cells[f.Address].SetSharedFormulaID(f.Index);
+                    _worksheet.Cells[f.Address].SetSharedFormulaID(f.Index, fIndexOriginal);
 
                 }
             }


### PR DESCRIPTION
Closes #378

Sometimes there can be an issue with the XML setting a f ref to an area that isn't correct and so when SetSharedFormulaID() sets the formula based on the f ref, it will set formulas incorrectly.
This can be resolved by checking each cell in the f ref shared cell range shares the same si (or in EPPlus' case id) as the initial shared cell

Created by ianpaul10